### PR TITLE
LinkedObjectPool - Object instantiation for non-Flash targets

### DIFF
--- a/src/de/polygonal/ds/pooling/LinkedObjectPool.hx
+++ b/src/de/polygonal/ds/pooling/LinkedObjectPool.hx
@@ -319,7 +319,7 @@ class LinkedObjectPool<T> implements Hashable
 			for (i in 0..._initSize)
 			{
 				var node = new ObjNode<T>();
-				node.val = Type.createInstance(_C, [])
+				node.val = Type.createInstance(_C, []);
 				t.next = node;
 				t = node;
 			}


### PR DESCRIPTION
There were a couple of _ _new_ _ calls in LinkedObjectPool that were stopping the cpp compile.

After making the change I've noticed that you already use Type.getInstance in the other Pool class/modules, so this was probably just missed.
