### PR TITLE
Added type param constraints to the HashSet/HashTable Iterator classes.

### DIFF
--- a/src/de/polygonal/ds/HashSet.hx
+++ b/src/de/polygonal/ds/HashSet.hx
@@ -601,7 +601,7 @@ class HashSet<T:Hashable> implements Set<T>
 private
 #end
 @:access(de.polygonal.ds.HashSet)
-class HashSetIterator<T> implements de.polygonal.ds.Itr<T>
+class HashSetIterator<T:Hashable> implements de.polygonal.ds.Itr<T>
 {
 	var mF:HashSet<T>;
 	

--- a/src/de/polygonal/ds/HashTable.hx
+++ b/src/de/polygonal/ds/HashTable.hx
@@ -819,7 +819,7 @@ class HashTable<K:Hashable, T> implements Map<K, T>
 private
 #end
 @:access(de.polygonal.ds.HashTable)
-class HashTableKeyIterator<K, T> implements de.polygonal.ds.Itr<K>
+class HashTableKeyIterator<K:Hashable, T> implements de.polygonal.ds.Itr<K>
 {
 	var mF:HashTable<K, T>;
 	
@@ -867,7 +867,7 @@ class HashTableKeyIterator<K, T> implements de.polygonal.ds.Itr<K>
 private
 #end
 @:access(de.polygonal.ds.HashTable)
-class HashTableValIterator<K, T> implements de.polygonal.ds.Itr<T>
+class HashTableValIterator<K:Hashable, T> implements de.polygonal.ds.Itr<T>
 {
 	var mF:HashTable<K, T>;
 	


### PR DESCRIPTION
To fix compilation problem when using latest development build of haxe.
