### PR TITLE
Fix error for js platform. 

### DIFF
--- a/src/de/polygonal/ds/mem/BitMemory.hx
+++ b/src/de/polygonal/ds/mem/BitMemory.hx
@@ -137,6 +137,8 @@ class BitMemory extends MemoryAccess
 		if (max == -1) max =
 		#if neko
 		neko.NativeString.length(input);
+		#elseif js
+		input.byteLength;
 		#else
 		input.length;
 		#end

--- a/src/de/polygonal/ds/mem/DoubleMemory.hx
+++ b/src/de/polygonal/ds/mem/DoubleMemory.hx
@@ -133,6 +133,8 @@ class DoubleMemory extends MemoryAccess
 		if (max == -1) max =
 		#if neko
 		neko.NativeString.length(input);
+		#elseif js
+		input.byteLength;
 		#else
 		input.length;
 		#end

--- a/src/de/polygonal/ds/mem/FloatMemory.hx
+++ b/src/de/polygonal/ds/mem/FloatMemory.hx
@@ -131,6 +131,8 @@ class FloatMemory extends MemoryAccess
 		if (max == -1) max =
 		#if neko
 		neko.NativeString.length(input);
+		#elseif js
+		input.byteLength;
 		#else
 		input.length;
 		#end

--- a/src/de/polygonal/ds/mem/IntMemory.hx
+++ b/src/de/polygonal/ds/mem/IntMemory.hx
@@ -230,6 +230,8 @@ class IntMemory extends MemoryAccess
 		if (max == -1) max =
 		#if neko
 		neko.NativeString.length(input);
+		#elseif js
+		input.byteLength;
 		#else
 		input.length;
 		#end

--- a/src/de/polygonal/ds/mem/ShortMemory.hx
+++ b/src/de/polygonal/ds/mem/ShortMemory.hx
@@ -134,6 +134,8 @@ class ShortMemory extends MemoryAccess
 		if (max == -1) max =
 		#if neko
 		neko.NativeString.length(input);
+		#elseif js
+		input.byteLength;
 		#else
 		input.length;
 		#end


### PR DESCRIPTION
The parameter length is missing for js target in Haxe 3.2.1, change for byteLength.

Not sure if it's more a bug in Haxe or the lib.