### PR TITLE
JVM support

### DIFF
--- a/src/polygonal/ds/Printf.hx
+++ b/src/polygonal/ds/Printf.hx
@@ -764,6 +764,8 @@ class Printf
 			s = untyped value.toFixed(p);
 			#elseif php
 			s = untyped __call__("number_format", value, p, ".", "");
+			#elseif jvm
+			s = java.NativeString.format(java.util.Locale.US, '%.${p}f', value);
 			#elseif java
 			s = untyped __java__("String.format({0}, {1})", '%.${p}f', value);
 			s = ~/,/.replace(s, ".");


### PR DESCRIPTION
Fixes compatibility with the JVM target merged to Haxe dev recently (https://github.com/HaxeFoundation/haxe/pull/8269).

In theory `NativeString` is now available on the regular Java target as well and would be nicer to use, but it wouldn't work with older Haxe versions, so I didn't touch that branch.