### PR TITLE
Fix PriorityQueue compilation on the eval target, closes #48

### DIFF
--- a/src/polygonal/ds/PriorityQueue.hx
+++ b/src/polygonal/ds/PriorityQueue.hx
@@ -288,7 +288,7 @@ class PriorityQueue<T:(Prioritizable)> implements Queue<T>
 	{
 		if (isEmpty()) return [];
 		
-		var out = ArrayTools.alloc(size);
+		var out:Array<T> = ArrayTools.alloc(size);
 		var t = mData.copy();
 		var k = size;
 		var j = 0, i, c, v, s, u;
@@ -533,7 +533,7 @@ class PriorityQueue<T:(Prioritizable)> implements Queue<T>
 	**/
 	public function toArray():Array<T>
 	{
-		return mData.toArray(1, size, []);
+		return NativeArrayTools.toArray(mData, 1, size, []);
 	}
 	
 	/**


### PR DESCRIPTION
This contains the type inference fix mentioned by Simn in #48, as well as a fix for the `toArray()` extension method call. `NativeArray` uses `eval.Vector` under the hood, [which also has a `toArray()` method of its own](https://github.com/HaxeFoundation/haxe/blob/727d882a1d037ace80e54964e9c20b5ab409cef8/std/eval/Vector.hx#L29), taking priority over the static extension.