### PR TITLE
Make objectpools mSet variable add new objects behind if-statement

### DIFF
--- a/src/ds/tools/ObjectPool.hx
+++ b/src/ds/tools/ObjectPool.hx
@@ -140,7 +140,6 @@ class ObjectPool<T>
 	{
 		#if debug
 		assert(!mSet.has(obj), 'object $obj was returned twice to the pool');
-		mSet.set(obj);
 		#end
 		
 		if (size == maxSize)
@@ -149,6 +148,9 @@ class ObjectPool<T>
 		{
 			if (size == mCapacity) resize();
 			mPool.set(size++, obj);
+			#if debug
+			mSet.set(obj);
+			#end
 		}
 	}
 	


### PR DESCRIPTION
ObjectPools mset could potentially grow indefinably, this PR puts it next to mPools set function as it is in the get-function to solve this problem.